### PR TITLE
Export populate as module

### DIFF
--- a/populate.js
+++ b/populate.js
@@ -78,7 +78,7 @@
 		define(function() {
 			return populate;
 		});
-	}	else if ( typeof exports === 'object' ) {
+	}	else if ( typeof module !== 'undefined' && module.exports ) {
 		module.exports = populate;
 	} else {
 		root.populate = populate;

--- a/populate.js
+++ b/populate.js
@@ -79,7 +79,7 @@
 			return populate;
 		});
 	}	else if ( typeof exports === 'object' ) {
-		exports.populate = populate;
+		module.exports = populate;
 	} else {
 		root.populate = populate;
 	}


### PR DESCRIPTION
When `require`ing the module it's exported on `.populate`.

This makes the following impossible:

``` js
var populate = require('populate');

populate(form, data); //object is not a function
```

Populate is actually exported on `.populate` so we'd have to get populate like so:

``` js
var populate = require('populate').populate;

populate(form, data);

//or

var populate = require('populate');

populate.populate(form, data);
```

I rewrote the exporting to export only the function.
