### PR TITLE
Bugfix: Add check for null or undefined variable

### DIFF
--- a/populate.js
+++ b/populate.js
@@ -19,6 +19,14 @@
 			var name = key;
 			var value = data[key];
 
+                        if ('undefined' === typeof value) {
+                            value = '';
+                        }
+
+                        if (null === value) {
+                            value = '';
+                        }
+
 			// handle array name attributes
 			if(typeof(basename) !== "undefined") {
 				name = basename + "[" + key + "]";


### PR DESCRIPTION
Actually, I get an error when a value is `null` or `undefined` in my object which populate the form.

In exemple:

``` js
formPopulate(document["form"], {
    address: undefined,
    birthdate: "1990-01-01"
})
```

I expect that the `birthdate` field is filled, and the `address` is set to empty.
Instead, I got a Javascript error `TypeError: value is undefined` that break the populate, and don't fill the `birthdate` field.