### PR TITLE
Make compatible with forms generated from Django models

### DIFF
--- a/example.html
+++ b/example.html
@@ -10,7 +10,7 @@
 	</style>
 </head>
 <body>
-
+	<h2>Form populated from a JSON object</h2>
 	<!-- The form we're going to populate -->
 	<form id="my-form">
 		<label>Name</label>
@@ -42,12 +42,25 @@
 		<input type="radio" name="gender" value="Male" /> Male
 		<input type="radio" name="gender" value="Female" /> Female
 
+		<label>Likes fruit?</label>
+		<input type="checkbox" name="likes_fruit" />
+
 		<label>Fruits</label>
 		<select name="fruits[]" multiple>
 			<option>Apples</option>
 			<option>Bananas</option>
 			<option>Oranges</option>
 		</select>
+	</form>
+
+	<h2>Object fields may also be left as JSON</h2>
+	<!-- A form showing the behavior of deserializeFields = false -->
+	<form id="deserialize-fields-example">
+		<label>Name</label>
+		<input type="text" name="name" />
+
+		<label>Address</label>
+		<textarea name="address" cols="40" rows="10"></textarea>
 	</form>
 
 
@@ -68,6 +81,7 @@
 			"age": 25,
 			"bio": "Some longer text with line-breaks.\n\nCool.",
 			"interests": [ "Eating", "Running" ],
+			"likes_fruit": true,
 			"fruits": [ "Apples", "Bananas", "Mango" ]
 		};
 
@@ -76,6 +90,10 @@
 
 		// populate the form with our JSON object
 		populate(formElement, data);
+
+		// show example with deserializeFields = false
+		formElement = document.getElementById('deserialize-fields-example');
+		populate(formElement, data, null, false);
 	</script>
 </body>
 </html>

--- a/populate.js
+++ b/populate.js
@@ -6,11 +6,12 @@
 	 *
 	 * @param form object The form element containing your input fields.
 	 * @param data array JSON data to populate the fields with.
-	 * @param basename string Optional basename which is added to `name` attributes
-	 * @param deserializeFields bool Optional flag. If true, data values of type object will be
-	 *   deserialized (i.e. "foo" : { "bar": 1 } would try to populate a field named "foo[bar]"
-	 *   with the value 1). If false, would instead try to populate a field named "foo" with
-	 *   (pretty-printed) JSON string '{ "bar": 1 }'.
+	 * @param basename string Optional basename which is added to `name` attributes. Used to
+	 *   deserialize object fields (i.e. {"foo": {"bar": 1}} will try to populate a field
+	 *   named "foo[bar]" with the value 1).
+	 * @param deserializeFields bool Optional flag. If false, {"foo": {"bar": 1}} would
+	 *   instead try to populate a field named "foo" with (pretty-printed) JSON string
+	 *  '{ "bar": 1 }'.
 	 */
 	var populate = function( form, data, basename, deserializeFields = true) {
 		if ('undefined' === typeof form.elements) {
@@ -72,7 +73,7 @@
 						}
 					}
 					else {
-						element.value = value;
+						element.checked = value > 0;
 					}
 					break;
 

--- a/populate.js
+++ b/populate.js
@@ -27,13 +27,13 @@
 			var name = key;
 			var value = data[key];
 
-                        if ('undefined' === typeof value) {
-                            value = '';
-                        }
+			if ('undefined' === typeof value) {
+				value = '';
+			}
 
-                        if (null === value) {
-                            value = '';
-                        }
+			if (null === value) {
+				value = '';
+			}
 
 			// handle array name attributes
 			if(basename) {


### PR DESCRIPTION
I wanted to use this with forms generated in a Django app. From a Django model that serializes like so:

```json
{
  "name": "nest",
  "is_occupied": false,
  "bird": 2,
  "details": {
    "date_constructed": "2018-11-30"
  }
}
```

You get a form with the structure (extra classes removed for brevity):

```html
<label for="id_name">Name:</label>
<input type="text" name="name" id="id_name">

<label for="id_is_occupied">Is occupied:</label>
<input type="checkbox" name="is_occupied" id="id_is_occupied">

<label for="id_bird">Bird:</label>
<select name="bird" id="id_bird">
  <option value="1">Swan</option>
  <option value="2">Goose</option>
  <option value="3">Duck</option>
  <option value="4">Other</option>
</select>

<label for="id_details">Details:</label>
<textarea name="details" id="id_details">
```

To populate such a form with the Django-serialized JSON, I:

1. Created a conditional that allowed for single checkboxes.
2. Added a `deserializeFields` parameter to the `populate` function, which defaults to `true` (the previous behaviour).

Examples for the new behavior are in example.html.

While I was at it, I added something to throw a more descriptive error if the "form" argument doesn't have `elements` defined.